### PR TITLE
Do not rely on TestKit's plugin classpath injection

### DIFF
--- a/confundus-gradle/build.gradle
+++ b/confundus-gradle/build.gradle
@@ -3,25 +3,12 @@ apply plugin: 'org.jetbrains.kotlin.kapt'
 apply plugin: 'java-gradle-plugin'
 apply from: "$rootDir/gradle/publish.gradle"
 
-configurations {
-  fixtureClasspath
-}
-
-// Append any extra dependencies to the test fixtures via a custom configuration classpath. This
-// allows us to apply additional plugins in a fixture while still leveraging dependency resolution
-// and de-duplication semantics.
-tasks.getByName('pluginUnderTestMetadata').
-    getPluginClasspath().
-    from(configurations.fixtureClasspath)
-
 dependencies {
   implementation deps.kotlin.stdlib.jdk
   compileOnly gradleApi()
   compileOnly deps.kotlin.gradlePlugin
   kapt deps.autoService.compiler
   compileOnly deps.autoService.annotations
-
-  fixtureClasspath deps.kotlin.gradlePlugin
 
   testImplementation deps.junit
   testImplementation deps.truth
@@ -42,6 +29,7 @@ gradlePlugin {
 test {
   dependsOn(':confundus-api:installArchives')
   dependsOn(':confundus-compiler:installArchives')
+  dependsOn(':confundus-gradle:installArchives')
 }
 
 def versionDirectory = "$buildDir/generated/version/"

--- a/confundus-gradle/src/test/fixture/jvm-ir/build.gradle
+++ b/confundus-gradle/src/test/fixture/jvm-ir/build.gradle
@@ -1,15 +1,18 @@
 buildscript {
+  dependencies {
+    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.71'
+    classpath "com.jakewharton.confundus:confundus-gradle:${confundusVersion}"
+  }
   repositories {
     maven {
       url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
     }
+    mavenCentral()
   }
 }
 
-plugins {
-  id 'org.jetbrains.kotlin.jvm'
-  id 'com.jakewharton.confundus'
-}
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.jakewharton.confundus'
 
 repositories {
   maven {

--- a/confundus-gradle/src/test/fixture/jvm/build.gradle
+++ b/confundus-gradle/src/test/fixture/jvm/build.gradle
@@ -1,15 +1,18 @@
 buildscript {
+  dependencies {
+    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.71'
+    classpath "com.jakewharton.confundus:confundus-gradle:${confundusVersion}"
+  }
   repositories {
     maven {
       url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
     }
+    mavenCentral()
   }
 }
 
-plugins {
-  id 'org.jetbrains.kotlin.jvm'
-  id 'com.jakewharton.confundus'
-}
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.jakewharton.confundus'
 
 repositories {
   maven {

--- a/confundus-gradle/src/test/fixture/mpp/build.gradle
+++ b/confundus-gradle/src/test/fixture/mpp/build.gradle
@@ -1,15 +1,18 @@
 buildscript {
+  dependencies {
+    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.71'
+    classpath "com.jakewharton.confundus:confundus-gradle:${confundusVersion}"
+  }
   repositories {
     maven {
       url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
     }
+    mavenCentral()
   }
 }
 
-plugins {
-  id 'org.jetbrains.kotlin.multiplatform'
-  id 'com.jakewharton.confundus'
-}
+apply plugin: 'org.jetbrains.kotlin.multiplatform'
+apply plugin: 'com.jakewharton.confundus'
 
 repositories {
   maven {

--- a/confundus-gradle/src/test/kotlin/com/jakewharton/confundus/gradle/ConfundusPluginTest.kt
+++ b/confundus-gradle/src/test/kotlin/com/jakewharton/confundus/gradle/ConfundusPluginTest.kt
@@ -8,6 +8,8 @@ import org.junit.Test
 class ConfundusPluginTest {
   private val fixturesDir = File("src/test/fixture")
 
+  private fun versionProperty() = "-PconfundusVersion=$confundusVersion"
+
   @Test fun jvm() {
     val fixtureDir = File(fixturesDir, "jvm")
     val gradleRoot = File(fixtureDir, "gradle").also { it.mkdir() }
@@ -15,8 +17,9 @@ class ConfundusPluginTest {
 
     val result = GradleRunner.create()
         .withProjectDir(fixtureDir)
-        .withPluginClasspath()
-        .withArguments("clean", "compileKotlin", "compileTestKotlin", "--stacktrace")
+        .withArguments(
+            "clean", "compileKotlin", "compileTestKotlin", "--stacktrace", versionProperty()
+        )
         .build()
     assertThat(result.output).contains("BUILD SUCCESSFUL")
   }
@@ -28,8 +31,9 @@ class ConfundusPluginTest {
 
     val result = GradleRunner.create()
         .withProjectDir(fixtureDir)
-        .withPluginClasspath()
-        .withArguments("clean", "compileKotlin", "compileTestKotlin", "--stacktrace")
+        .withArguments(
+            "clean", "compileKotlin", "compileTestKotlin", "--stacktrace", versionProperty()
+        )
         .build()
     assertThat(result.output).contains("BUILD SUCCESSFUL")
   }
@@ -41,12 +45,11 @@ class ConfundusPluginTest {
 
     val result = GradleRunner.create()
         .withProjectDir(fixtureDir)
-        .withPluginClasspath()
         .withArguments(
             "clean",
             "compileKotlinJvm", "compileTestKotlinJvm",
             "compileKotlinJvm2", "compileTestKotlinJvm2",
-            "--stacktrace"
+            "--stacktrace", versionProperty()
         )
         .build()
     assertThat(result.output).contains("BUILD SUCCESSFUL")


### PR DESCRIPTION
It creates all kind of problems for loading additional plugins with mutual dependencies. Intsead, install it to the repo-local Maven repo like the other artifacts and pull it normally.